### PR TITLE
Specify country in which the tax classification is defined.

### DIFF
--- a/entity/AccountingLedgerEntities.xml
+++ b/entity/AccountingLedgerEntities.xml
@@ -717,14 +717,14 @@ along with this software (see the LICENSE.md file). If not, see
 
             <!-- Tax Classification -->
             <moqui.basic.EnumerationType description="Tax Classification" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="Individual, Sole Proprietor, Single-member LLC" enumId="TxcIndividual" sequenceNum="1" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="C Corporation" enumId="TxcCCorp" sequenceNum="2" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="S Corporation" enumId="TxcSCorp" sequenceNum="3" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="Partnership" enumId="TxcPartnership" sequenceNum="4" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="Trust/Estate" enumId="TxcTrustEstate" sequenceNum="5" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="LLC as S Corp" enumId="TxcLlcSCorp" sequenceNum="6" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="LLC as C Corp" enumId="TxcLlcCCorp" sequenceNum="7" enumTypeId="TaxClassification"/>
-            <moqui.basic.Enumeration description="LLC as Partnership" enumId="TxcLlcPartnership" sequenceNum="8" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - Individual, Sole Proprietor, Single-member LLC" enumId="TxcIndividual" sequenceNum="1" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - C Corporation" enumId="TxcCCorp" sequenceNum="2" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - S Corporation" enumId="TxcSCorp" sequenceNum="3" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - Partnership" enumId="TxcPartnership" sequenceNum="4" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - Trust/Estate" enumId="TxcTrustEstate" sequenceNum="5" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - LLC as S Corp" enumId="TxcLlcSCorp" sequenceNum="6" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - LLC as C Corp" enumId="TxcLlcCCorp" sequenceNum="7" enumTypeId="TaxClassification"/>
+            <moqui.basic.Enumeration description="USA - LLC as Partnership" enumId="TxcLlcPartnership" sequenceNum="8" enumTypeId="TaxClassification"/>
             <moqui.basic.Enumeration description="Other" enumId="TxcOther" sequenceNum="9" enumTypeId="TaxClassification"/>
 
             <!-- Cost Of Goods Sold methods -->


### PR DESCRIPTION
While adding local country-specific tax classifications, thought it would be useful to have them show in the description which specific origin the tax classifications have.
It might seem redundant, but as specific local legal requirements apply differently to an organization according to its classification, it seems necessary to maintain country-specific classes. This defines also what authority you would submit reports for that organization, specific XBRL formats to use, etc.