### PR TITLE
Wiki blog - entity

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Written in 2014-2015 by Abdullah Shaikh - abdullahs
 Written in 2015-2016 by Jens Hardings - jenshp
 Written in 2015-     by Dony Zulkarnaen - donniexyz
 Written in 2015 by Anton Akhiar - akhiar
+Written in 2017      by Oleg Andrieiev - oandreyev
 
 ===========================================================================
 
@@ -70,3 +71,4 @@ Written in 2015-2016 by Jens Hardings - jenshp
 Written in 2015 by Dony Zulkarnaen - donniexyz
 Written in 2012-2015 by Sam Hamilton - samhamilton
 Written in 2015 by Anton Akhiar - akhiar
+Written in 2017 by Oleg Andrieiev - oandreyev

--- a/entity/ResourceEntities.xml
+++ b/entity/ResourceEntities.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This software is in the public domain under CC0 1.0 Universal plus a
+Grant of Patent License.
+
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to the
+public domain worldwide. This software is distributed without any
+warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication
+along with this software (see the LICENSE.md file). If not, see
+<http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-definition-2.1.xsd">
+
+    <entity entity-name="WikiBlog" package="mantle.resource.wiki">
+        <field name="wikiBlogId" type="id" is-pk="true"/>
+        <field name="wikiSpaceId" type="id"/>
+        <field name="title" type="text-medium"/>
+        <field name="author" type="text-medium"/>
+        <field name="publishDate" type="date-time"/>
+        <field name="metaKeywords" type="text-long"/>
+        <field name="metaDescription" type="text-long"/>
+        <field name="smallImageLocation" type="text-medium"/>
+        <field name="blogLocation" type="text-medium"/>
+        <relationship type="one" related="moqui.resource.wiki.WikiSpace" short-alias="space"/>
+    </entity>
+
+</entities>


### PR DESCRIPTION
Add an entity for wiki blog metadata.

Some features of use:
**smallImageLocation** contains dbresource url
**blogLocation** contains wiki page path