### PR TITLE
Create InvoiceTypePaymentType config

### DIFF
--- a/entity/AccountingAccountEntities.xml
+++ b/entity/AccountingAccountEntities.xml
@@ -1469,6 +1469,8 @@ along with this software (see the LICENSE.md file). If not, see
             <!-- Payment for deposit to or withdrawal from a FinancialAccount, never applied to an invoice -->
             <moqui.basic.Enumeration description="Financial Account Transaction" enumId="PtFinancialAccount" enumTypeId="PaymentType"/>
             <moqui.basic.Enumeration description="Order Payment Preference" enumId="PtOrderPref" enumTypeId="PaymentType"/>
+            <moqui.basic.Enumeration description="Payroll Employee Payment" enumId="PtPayrollPayment" enumTypeId="PaymentType"/>
+            <moqui.basic.Enumeration description="Payroll Other Payment" enumId="PtPayrollOtherPayment" enumTypeId="PaymentType"/>
 
             <!-- Payment Instrument -->
             <moqui.basic.EnumerationType description="Payment Instrument" enumTypeId="PaymentInstrument"/>

--- a/entity/AccountingLedgerEntities.xml
+++ b/entity/AccountingLedgerEntities.xml
@@ -387,6 +387,18 @@ along with this software (see the LICENSE.md file). If not, see
             <key-map field-name="organizationPartyId"/></relationship>
         <relationship type="one" related="mantle.ledger.account.GlAccount"/>
     </entity>
+    <entity entity-name="InvoiceTypePaymentType" package="mantle.ledger.config" use="configuration">
+        <field name="invoiceTypeEnumId" type="id" is-pk="true"/>
+        <field name="paymentTypeEnumId" type="id"/>
+        <relationship type="one" title="InvoiceType" related="moqui.basic.Enumeration">
+            <key-map field-name="invoiceTypeEnumId"/></relationship>
+        <relationship type="one" title="PaymentType" related="moqui.basic.Enumeration">
+            <key-map field-name="paymentTypeEnumId"/></relationship>
+        <seed-data>
+            <mantle.ledger.config.InvoiceTypePaymentType invoiceTypeEnumId="InvoicePayroll" paymentTypeEnumId="PtPayrollPayment"/>
+            <mantle.ledger.config.InvoiceTypePaymentType invoiceTypeEnumId="InvoicePayrollOther" paymentTypeEnumId="PtPayrollOtherPayment"/>
+        </seed-data>
+    </entity>
     <entity entity-name="PaymentInstrumentGlAccount" package="mantle.ledger.config" use="configuration">
         <field name="paymentInstrumentEnumId" type="id" is-pk="true"/>
         <field name="organizationPartyId" type="id" is-pk="true"/>


### PR DESCRIPTION
When adding a payment for an invoice using mantle.account.PaymentServices.create#InvoicePayment the default PaymentType is PtInvoicePayment. This implies that all payments of invoices are handled using the same Payment Type to GlAccount mapping.
When different invoiceTypes have different GlAccount mappings, only one of the mappings will match the corresponding mapping for the PtInvoicePayment.
For instance, the posting of an invoice of type InvoiceSales will credit the AP account, and the corresponding payment posting will debit the same AP account. But if you configure the glAccount mapping for the InvoicePayroll to a different account, the corresponding payment will be posted crediting the AP account.
This pull request creates the mantle.ledger.config.InvoiceTypePaymentType mapping table to configure what paymentType to use, which is then used to determine which glAccount to credit as default when creating a payment for a specific invoice.
This invoice type to payment type mapping cannot be specific to an organization and thus has no organizationPartyId, because in one payment there can be two internalOrg parties involved, so the organization-specific setting is left to the PaymentTypeGlAccount mapping.