### PR TITLE
Invoice payment mapping

### DIFF
--- a/entity/AccountingAccountEntities.xml
+++ b/entity/AccountingAccountEntities.xml
@@ -411,8 +411,8 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.EnumerationType description="Invoice Type" enumTypeId="InvoiceType"/>
             <moqui.basic.Enumeration description="Sales/Purchase" enumId="InvoiceSales" enumTypeId="InvoiceType"/>
             <moqui.basic.Enumeration description="Return" enumId="InvoiceReturn" enumTypeId="InvoiceType"/>
-            <moqui.basic.Enumeration description="Payroll Employee" enumId="InvoicePayroll" enumTypeId="InvoiceType"/>
-            <moqui.basic.Enumeration description="Payroll Other" enumId="InvoicePayrollOther" enumTypeId="InvoiceType"/>
+            <moqui.basic.Enumeration description="Payroll Employee" enumId="InvoicePayroll" enumTypeId="InvoiceType" relatedEnumId="PtPayrollPayment"/>
+            <moqui.basic.Enumeration description="Payroll Other" enumId="InvoicePayrollOther" enumTypeId="InvoiceType" relatedEnumId="PtPayrollOtherPayment"/>
             <moqui.basic.Enumeration description="Tax" enumId="InvoiceTax" enumTypeId="InvoiceType"/>
             <moqui.basic.Enumeration description="Garnishment" enumId="InvoiceGarnishment" enumTypeId="InvoiceType"/>
             <moqui.basic.Enumeration description="Commission" enumId="InvoiceCommission" enumTypeId="InvoiceType"/>

--- a/entity/AccountingAccountEntities.xml
+++ b/entity/AccountingAccountEntities.xml
@@ -1472,6 +1472,9 @@ along with this software (see the LICENSE.md file). If not, see
             <!-- Payment for deposit to or withdrawal from a FinancialAccount, never applied to an invoice -->
             <moqui.basic.Enumeration description="Financial Account Transaction" enumId="PtFinancialAccount" enumTypeId="PaymentType"/>
             <moqui.basic.Enumeration description="Order Payment Preference" enumId="PtOrderPref" enumTypeId="PaymentType"/>
+            <!-- Payment of payroll invoices -->
+            <moqui.basic.Enumeration description="Payroll Employee Payment" enumId="PtPayrollPayment" enumTypeId="PaymentType" parentEnumId="PtInvoicePayment"/>
+            <moqui.basic.Enumeration description="Payroll Other Payment" enumId="PtPayrollOtherPayment" enumTypeId="PaymentType" parentEnumId="PtInvoicePayment"/>
 
             <!-- Payment Instrument -->
             <moqui.basic.EnumerationType description="Payment Instrument" enumTypeId="PaymentInstrument"/>


### PR DESCRIPTION
As commented in https://github.com/moqui/mantle-udm/pull/77, this includes definition for PaymentTypes for Payroll and PayrollOther payments, along with a mapping from InvoiceType to PaymentType through relatedEnumId, which is used when creating a payment for an invoice (see https://github.com/moqui/mantle-usl/pull/139)