### PR TITLE
Add OrderHeader.merchantId with description

### DIFF
--- a/entity/OrderEntities.xml
+++ b/entity/OrderEntities.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -73,6 +73,7 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="salesChannelEnumId" type="id"/>
 
         <field name="terminalId" type="text-short"><description>ID for the terminal, such as a POS system, where the order was recorded</description></field>
+        <field name="merchantId" type="text-short"><description>ID for a merchant of a productStore</description></field>
         <field name="displayId" type="text-short"><description>ID to display to customers, can be different from orderId and/or externalId</description></field>
         <field name="externalId" type="text-short"><description>ID for the order in the direct upstream system it came from if it came from an external system</description></field>
         <field name="externalRevision" type="text-short"/>


### PR DESCRIPTION
In the event that a productStore's party organization is consisted of multiple sub-store merchants, the system architect wants to keep minimal data on each merchant, and the merchant's orders needs to be kept track of, adding a merchantId to the OrderHeader entity is the a way to comply with these parameters.

Another solution, is to set the OrderHeader's partyId's partyIdentificationEnumId with a merchantId. Then the party can be associated with different merchants, but in the scenario that the same party is used for different merchants a OrderHeader.merchantId would still be necessary to differentiate between which merchant corresponds to a given order.

In the scenario that a productStore wants to have different parties depending on which merchant system the customer logs on to, a partyIdentification merchantIdTypeEnumId with the merchantId as the value field can distinguish between different merchant systems, and isolate their UserAccounts. 