### PR TITLE
Add ProductCategoryIdent, ProductStoreDataDocument, and ProductIdentificationType URL Slug

### DIFF
--- a/entity/ProductDefinitionEntities.xml
+++ b/entity/ProductDefinitionEntities.xml
@@ -474,11 +474,10 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.Enumeration description="EAN" enumId="PidtEan"  enumTypeId="ProductIdentificationType"/>
             <moqui.basic.Enumeration description="GTIN" enumId="PidtGtin"  enumTypeId="ProductIdentificationType"/>
             <moqui.basic.Enumeration description="Library of Congress" enumId="PidtLoc"  enumTypeId="ProductIdentificationType"/>
+            <!-- see https://en.wikipedia.org/wiki/Clean_URL#Slug -->
             <moqui.basic.Enumeration description="URL Slug" enumId="PidtUrlSlug"  enumTypeId="ProductIdentificationType"/>
             <!-- see https://en.wikipedia.org/wiki/Harmonized_Tariff_Schedule_of_the_United_States and https://hts.usitc.gov/ -->
             <moqui.basic.Enumeration description="HTS (Tariff)" enumId="PidtHts"  enumTypeId="ProductIdentificationType"/>
-            <!-- see https://en.wikipedia.org/wiki/Clean_URL#Slug -->
-            <moqui.basic.Enumeration description="URL Slug" enumId="PidtSlug"  enumTypeId="ProductIdentificationType"/>
         </seed-data>
     </entity>
     <entity entity-name="ProductOtherIdentification" package="mantle.product">
@@ -832,12 +831,12 @@ along with this software (see the LICENSE.md file). If not, see
         <description>Based on mantle.product.ProductOtherIdentification to be a one ProductCategory to many ProductCategoryIdent.</description>
         <field name="productCategoryIdentId" type="id" is-pk="true"/>
         <field name="productCategoryId" type="id"/>
-        <field name="productCategoryIdentTypeEnumId" type="id"/>
+        <field name="identTypeEnumId" type="id"/>
         <field name="productStoreId" type="id"/>
         <field name="marketSegmentId" type="id"/>
         <field name="idValue" type="text-medium"/>
         <relationship type="one" title="ProductCategoryIdentType" related="moqui.basic.Enumeration" short-alias="type">
-            <key-map field-name="productCategoryIdentTypeEnumId"/></relationship>
+            <key-map field-name="identTypeEnumId"/></relationship>
         <relationship type="one" related="mantle.product.category.ProductCategory" short-alias="productCategory"/>
         <relationship type="one" related="mantle.product.store.ProductStore" short-alias="productStore"/>
         <relationship type="one" related="mantle.marketing.segment.MarketSegment" short-alias="marketSegment"/>
@@ -846,7 +845,7 @@ along with this software (see the LICENSE.md file). If not, see
             <!-- Product Category Ident Type -->
             <moqui.basic.EnumerationType description="Product Category Ident Type" enumTypeId="ProductCategoryIdentType"/>
             <!-- see https://en.wikipedia.org/wiki/Clean_URL#Slug -->
-            <moqui.basic.Enumeration description="URL Slug" enumId="PcitSlug" enumTypeId="ProductCategoryIdentType"/>
+            <moqui.basic.Enumeration description="URL Slug" enumId="PcitUrlSlug" enumTypeId="ProductCategoryIdentType"/>
         </seed-data>
     </entity>
 

--- a/entity/ProductDefinitionEntities.xml
+++ b/entity/ProductDefinitionEntities.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -102,6 +102,8 @@ along with this software (see the LICENSE.md file). If not, see
             <key-map field-name="productId"/></relationship>
         <relationship type="many" related="mantle.product.ProductIdentification" short-alias="identifications">
             <key-map field-name="productId"/></relationship>
+        <relationship type="many" related="mantle.product.ProductOtherIdentification" short-alias="otherIdentifications">
+            <key-map field-name="productId"/></relationship>
         <relationship type="many" related="mantle.product.ProductParty" short-alias="parties">
             <key-map field-name="productId"/></relationship>
         <relationship type="many" related="mantle.product.ProductPrice" short-alias="prices">
@@ -175,6 +177,7 @@ along with this software (see the LICENSE.md file). If not, see
             <detail relationship="dimensions"/>
             <detail relationship="geos"><detail relationship="geo"/></detail>
             <detail relationship="identifications"><detail relationship="type"/></detail>
+            <detail relationship="otherIdentifications"><detail relationship="type"/></detail>
             <detail relationship="parties"><detail relationship="party" use-master="basic"/><detail relationship="role"/></detail>
             <detail relationship="prices">
                 <detail relationship="type"/>
@@ -473,6 +476,8 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.Enumeration description="Library of Congress" enumId="PidtLoc"  enumTypeId="ProductIdentificationType"/>
             <!-- see https://en.wikipedia.org/wiki/Harmonized_Tariff_Schedule_of_the_United_States and https://hts.usitc.gov/ -->
             <moqui.basic.Enumeration description="HTS (Tariff)" enumId="PidtHts"  enumTypeId="ProductIdentificationType"/>
+            <!-- see https://en.wikipedia.org/wiki/Clean_URL#Slug -->
+            <moqui.basic.Enumeration description="URL Slug" enumId="PidtSlug"  enumTypeId="ProductIdentificationType"/>
         </seed-data>
     </entity>
     <entity entity-name="ProductOtherIdentification" package="mantle.product">
@@ -739,6 +744,8 @@ along with this software (see the LICENSE.md file). If not, see
             <key-map field-name="productCategoryId"/></relationship>
         <relationship type="many" related="mantle.product.category.ProductCategoryParty" short-alias="parties">
             <key-map field-name="productCategoryId"/></relationship>
+        <relationship type="many" related="mantle.product.category.ProductCategoryIdent" short-alias="identifications">
+            <key-map field-name="productCategoryId"/></relationship>
         <relationship type="many" related="mantle.product.category.ProductCategoryMember" short-alias="products">
             <key-map field-name="productCategoryId"/></relationship>
         <relationship type="many" related="mantle.product.category.ProductCategoryRollup" short-alias="parents">
@@ -746,6 +753,8 @@ along with this software (see the LICENSE.md file). If not, see
         <relationship type="many" related="mantle.product.category.ProductCategoryRollup" short-alias="children">
             <key-map field-name="productCategoryId" related="parentProductCategoryId"/></relationship>
         <relationship type="many" related="mantle.product.feature.ProductCategoryFeatGrpAppl" short-alias="featureGroups">
+            <key-map field-name="productCategoryId"/></relationship>
+        <relationship type="many" related="mantle.product.store.ProductStoreCategory" short-alias="storeCategories">
             <key-map field-name="productCategoryId"/></relationship>
 
         <index name="CATEGORY_ID_PSEUDO" unique="true"><index-field name="pseudoId"/><index-field name="ownerPartyId"/></index>
@@ -790,7 +799,7 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="sequenceNum" type="number-integer"/>
         <field name="userId" type="id" default="ec.user.userId"/>
         <relationship type="one" related="mantle.product.category.ProductCategory"/>
-        <relationship type="one" title="ProductCategoryContentType" related="moqui.basic.Enumeration">
+        <relationship type="one" title="ProductCategoryContentType" related="moqui.basic.Enumeration" short-alias="type">
             <key-map field-name="categoryContentTypeEnumId"/></relationship>
         <relationship type="one" related="mantle.product.store.ProductStore" short-alias="store"/>
         <index name="PRDCAT_CNT_CTTP"><index-field name="productCategoryId"/><index-field name="categoryContentTypeEnumId"/></index>
@@ -817,6 +826,27 @@ along with this software (see the LICENSE.md file). If not, see
         <relationship type="one" related="mantle.product.category.ProductCategory" short-alias="category"/>
         <relationship type="one" related="mantle.party.Party" short-alias="party"/>
         <relationship type="one" related="mantle.party.RoleType" short-alias="role"/>
+    </entity>
+    <entity entity-name="ProductCategoryIdent" package="mantle.product.category">
+        <description>Based on mantle.product.ProductOtherIdentification to be a one ProductCategory to many ProductCategoryIdent.</description>
+        <field name="productCategoryIdentId" type="id" is-pk="true"/>
+        <field name="productCategoryId" type="id"/>
+        <field name="productCategoryIdentTypeEnumId" type="id"/>
+        <field name="productStoreId" type="id"/>
+        <field name="marketSegmentId" type="id"/>
+        <field name="idValue" type="text-medium"/>
+        <relationship type="one" title="ProductCategoryIdentType" related="moqui.basic.Enumeration" short-alias="type">
+            <key-map field-name="productCategoryIdentTypeEnumId"/></relationship>
+        <relationship type="one" related="mantle.product.category.ProductCategory" short-alias="productCategory"/>
+        <relationship type="one" related="mantle.product.store.ProductStore" short-alias="productStore"/>
+        <relationship type="one" related="mantle.marketing.segment.MarketSegment" short-alias="marketSegment"/>
+        <index name="PRODUCT_CAT_STR_ID_VAL" unique="false"><index-field name="idValue"/></index>
+        <seed-data>
+            <!-- Product Category Ident Type -->
+            <moqui.basic.EnumerationType description="Product Category Ident Type" enumTypeId="ProductCategoryIdentType"/>
+            <!-- see https://en.wikipedia.org/wiki/Clean_URL#Slug -->
+            <moqui.basic.Enumeration description="URL Slug" enumId="PcitSlug" enumTypeId="ProductCategoryIdentType"/>
+        </seed-data>
     </entity>
 
     <entity entity-name="ProductCategoryMember" package="mantle.product.category">
@@ -1178,7 +1208,7 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="applTypeEnumId" type="id"/>
         <relationship type="one" related="mantle.product.category.ProductCategory" short-alias="category"/>
         <relationship type="one" related="mantle.product.feature.ProductFeatureGroup" short-alias="group"/>
-        <relationship type="one" title="ProductFeatureApplType" related="moqui.basic.Enumeration">
+        <relationship type="one" title="ProductFeatureApplType" related="moqui.basic.Enumeration" short-alias="type">
             <key-map field-name="applTypeEnumId"/></relationship>
     </entity>
     <entity entity-name="ProductFeatureGroup" package="mantle.product.feature" short-alias="featureGroups">

--- a/entity/ProductStoreEntities.xml
+++ b/entity/ProductStoreEntities.xml
@@ -47,9 +47,9 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="profileUrlPath" type="text-medium"><description>Path to profile page for use in emails</description></field>
         <field name="wikiSpaceId" type="id"><description>For a WikiSpace mounted as content, superceded by ProductStoreWikiSpace with spaceTypeEnumId=PstFull</description></field>
         <!-- TODO: Warning dataDocumentId fields are to be deprecated in favor of the ProductStoreDataDocument entity -->
-        <field name="contentDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor of a ProductStoreDataDocument entity with a storeDocumentTypeEnumId of PsdtContent. The dataDocumentId to use for search of content pages in wikiSpaceId</description></field>
-        <field name="blogDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor a ProductStoreDataDocument entity with a storeDocumentTypeEnumId of PsdtBlog. The dataDocumentId to use for search of blog entries</description></field>
-        <field name="productDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor of a ProductStoreDataDocument entity with a storeDocumentTypeEnumId of PsdtProduct. The dataDocumentId to use for product search</description></field>
+        <field name="contentDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor of a ProductStoreDataDocument entity with a typeEnumId of PsdtContent. The dataDocumentId to use for search of content pages in wikiSpaceId</description></field>
+        <field name="blogDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor a ProductStoreDataDocument entity with a typeEnumId of PsdtBlog. The dataDocumentId to use for search of blog entries</description></field>
+        <field name="productDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor of a ProductStoreDataDocument entity with a typeEnumId of PsdtProduct. The dataDocumentId to use for product search</description></field>
 
         <field name="defaultLocale" type="text-short"/>
         <field name="defaultCurrencyUomId" type="id"/>
@@ -530,14 +530,14 @@ along with this software (see the LICENSE.md file). If not, see
     <entity entity-name="ProductStoreDataDocument" package="mantle.product.store">
         <description>Relationship between the ProductStore and DataDocument Entities meant to replace ProductStore.productDataDocumentId fields and the like. See: https://forum.moqui.org/t/productstore-datadocument-options/303.</description>
         <field name="productStoreId" type="id" is-pk="true"/>
-        <field name="storeDocumentTypeEnumId" type="id" is-pk="true"/>
+        <field name="typeEnumId" type="id" is-pk="true"/>
         <field name="dataDocumentId" type="id"/>
 
         <!-- TODO: Are these many relationships? -->
         <relationship type="one" related="mantle.product.store.ProductStore" short-alias="store"/>
         <relationship type="one" related="moqui.entity.document.DataDocument" short-alias="dataDocument"/>
         <relationship type="one" title="StoreDataDocumentType" related="moqui.basic.Enumeration" short-alias="type">
-            <key-map field-name="storeDocumentTypeEnumId"/></relationship>
+            <key-map field-name="typeEnumId"/></relationship>
 
         <seed-data>
             <moqui.basic.EnumerationType description="Product Store Data Document Type" enumTypeId="ProductStoreDataDocumentType"/>

--- a/entity/ProductStoreEntities.xml
+++ b/entity/ProductStoreEntities.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -75,6 +75,9 @@ along with this software (see the LICENSE.md file). If not, see
             <key-map field-name="returnPostalContactMechId"/></relationship>
 
         <relationship type="one" related="moqui.resource.wiki.WikiSpace" short-alias="wikiSpace"/>
+        <relationship type="many" related="mantle.product.store.ProductStoreDataDocument" short-alias="storeDataDocuments">
+            <key-map field-name="productStoreId"/></relationship>
+        <!-- TODO: dataDocumentId fields are to be depricated -->
         <relationship type="one" title="Content" related="moqui.entity.document.DataDocument" short-alias="contentDataDocument">
             <key-map field-name="contentDataDocumentId"/></relationship>
         <relationship type="one" title="Blog" related="moqui.entity.document.DataDocument" short-alias="blogDataDocument">
@@ -517,6 +520,32 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.Enumeration enumCode="template_server_home" description="Home Template - Server" enumId="PsctHomeTemplateServer" enumTypeId="ProductStoreContentType"/>
             <moqui.basic.Enumeration enumCode="template_server_category" description="Category Template - Server" enumId="PsctCategoryTemplateServer" enumTypeId="ProductStoreContentType"/>
             <moqui.basic.Enumeration enumCode="template_server_product" description="Product Template - Server" enumId="PsctProductTemplateServer" enumTypeId="ProductStoreContentType"/>
+        </seed-data>
+    </entity>
+
+    <extend-entity entity-name="DataDocument" package="moqui.entity.document">
+        <relationship type="many" related="mantle.product.store.ProductStoreDataDocument" short-alias="storeDataDocuments">
+            <key-map field-name="dataDocumentId"/></relationship>
+    </extend-entity>
+    <entity entity-name="ProductStoreDataDocument" package="mantle.product.store">
+        <description>Relationship between the ProductStore and DataDocument Entities meant to replace ProductStore.productDataDocumentId fields and the like. See: https://forum.moqui.org/t/productstore-datadocument-options/303.</description>
+        <field name="productStoreId" type="id" is-pk="true"/>
+        <field name="storeDataDocumentTypeEnumId" type="id" is-pk="true"/>
+        <field name="dataDocumentId" type="id"/>
+
+        <!-- TODO: Are these many relationships? -->
+        <relationship type="one" related="mantle.product.store.ProductStore" short-alias="store"/>
+        <relationship type="one" related="moqui.entity.document.DataDocument" short-alias="dataDocument"/>
+        <relationship type="one" title="StoreDataDocumentType" related="moqui.basic.Enumeration" short-alias="type">
+            <key-map field-name="storeDataDocumentTypeEnumId"/></relationship>
+
+        <seed-data>
+            <moqui.basic.EnumerationType description="Product Store Data Document Type" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Store - Product Data Document" enumId="PsdtProduct" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Store - Category Data Document" enumId="PsdtCategory" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Store - Blog Data Document" enumId="PsdtBlog" enumTypeId="ProductStoreDataDocumentType"/>
+            <!-- TODO: What type of Content was the ProductStore.contentDataDocumentId for? -->
+            <moqui.basic.Enumeration description="Store - Content Data Document" enumId="PsdtContent" enumTypeId="ProductStoreDataDocumentType"/>
         </seed-data>
     </entity>
 

--- a/entity/ProductStoreEntities.xml
+++ b/entity/ProductStoreEntities.xml
@@ -46,9 +46,10 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="storeDomain" type="text-short"><description>Store domain for use in emails</description></field>
         <field name="profileUrlPath" type="text-medium"><description>Path to profile page for use in emails</description></field>
         <field name="wikiSpaceId" type="id"><description>For a WikiSpace mounted as content, superceded by ProductStoreWikiSpace with spaceTypeEnumId=PstFull</description></field>
-        <field name="contentDataDocumentId" type="id"><description>The dataDocumentId to use for search of content pages in wikiSpaceId</description></field>
-        <field name="blogDataDocumentId" type="id"><description>The dataDocumentId to use for search of blog entries</description></field>
-        <field name="productDataDocumentId" type="id"><description>The dataDocumentId to use for product search</description></field>
+        <!-- TODO: Warning dataDocumentId fields are to be deprecated in favor of the ProductStoreDataDocument entity -->
+        <field name="contentDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor of a ProductStoreDataDocument entity with a storeDocumentTypeEnumId of PsdtContent. The dataDocumentId to use for search of content pages in wikiSpaceId</description></field>
+        <field name="blogDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor a ProductStoreDataDocument entity with a storeDocumentTypeEnumId of PsdtBlog. The dataDocumentId to use for search of blog entries</description></field>
+        <field name="productDataDocumentId" type="id"><description>Warning: this field to be deprecated in favor of a ProductStoreDataDocument entity with a storeDocumentTypeEnumId of PsdtProduct. The dataDocumentId to use for product search</description></field>
 
         <field name="defaultLocale" type="text-short"/>
         <field name="defaultCurrencyUomId" type="id"/>
@@ -77,7 +78,6 @@ along with this software (see the LICENSE.md file). If not, see
         <relationship type="one" related="moqui.resource.wiki.WikiSpace" short-alias="wikiSpace"/>
         <relationship type="many" related="mantle.product.store.ProductStoreDataDocument" short-alias="storeDataDocuments">
             <key-map field-name="productStoreId"/></relationship>
-        <!-- TODO: dataDocumentId fields are to be depricated -->
         <relationship type="one" title="Content" related="moqui.entity.document.DataDocument" short-alias="contentDataDocument">
             <key-map field-name="contentDataDocumentId"/></relationship>
         <relationship type="one" title="Blog" related="moqui.entity.document.DataDocument" short-alias="blogDataDocument">
@@ -530,22 +530,22 @@ along with this software (see the LICENSE.md file). If not, see
     <entity entity-name="ProductStoreDataDocument" package="mantle.product.store">
         <description>Relationship between the ProductStore and DataDocument Entities meant to replace ProductStore.productDataDocumentId fields and the like. See: https://forum.moqui.org/t/productstore-datadocument-options/303.</description>
         <field name="productStoreId" type="id" is-pk="true"/>
-        <field name="storeDataDocumentTypeEnumId" type="id" is-pk="true"/>
+        <field name="storeDocumentTypeEnumId" type="id" is-pk="true"/>
         <field name="dataDocumentId" type="id"/>
 
         <!-- TODO: Are these many relationships? -->
         <relationship type="one" related="mantle.product.store.ProductStore" short-alias="store"/>
         <relationship type="one" related="moqui.entity.document.DataDocument" short-alias="dataDocument"/>
         <relationship type="one" title="StoreDataDocumentType" related="moqui.basic.Enumeration" short-alias="type">
-            <key-map field-name="storeDataDocumentTypeEnumId"/></relationship>
+            <key-map field-name="storeDocumentTypeEnumId"/></relationship>
 
         <seed-data>
             <moqui.basic.EnumerationType description="Product Store Data Document Type" enumTypeId="ProductStoreDataDocumentType"/>
-            <moqui.basic.Enumeration description="Store - Product Data Document" enumId="PsdtProduct" enumTypeId="ProductStoreDataDocumentType"/>
-            <moqui.basic.Enumeration description="Store - Category Data Document" enumId="PsdtCategory" enumTypeId="ProductStoreDataDocumentType"/>
-            <moqui.basic.Enumeration description="Store - Blog Data Document" enumId="PsdtBlog" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Product Search" enumId="PsdtProduct" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Category Search" enumId="PsdtCategory" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Blog Search" enumId="PsdtBlog" enumTypeId="ProductStoreDataDocumentType"/>
             <!-- TODO: What type of Content was the ProductStore.contentDataDocumentId for? -->
-            <moqui.basic.Enumeration description="Store - Content Data Document" enumId="PsdtContent" enumTypeId="ProductStoreDataDocumentType"/>
+            <moqui.basic.Enumeration description="Content Search" enumId="PsdtContent" enumTypeId="ProductStoreDataDocumentType"/>
         </seed-data>
     </entity>
 


### PR DESCRIPTION
Add ProductOtherIdentification relationship to Product, Add ProductIdentificationType URL Slug, Add ProductStoreDataDocument and relationships, Add ProductCategoryIdent and relationships.

Related to:
- https://github.com/moqui/SimpleScreens/pull/132
- https://github.com/moqui/mantle-usl/pull/189
- https://github.com/moqui/PopCommerce/pull/56

As discussed in 
- https://forum.moqui.org/t/productstore-datadocument-options/303/2
- https://forum.moqui.org/t/moqui-slug-data-model-handling/289/12